### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![Carthage compatible](https://img.shields.io/badge/Carthage-compatible-4BC51D.svg?style=flat)](https://github.com/Carthage/Carthage)
-[![Cocoapods compatible](https://img.shields.io/badge/Cocoapods-compatible-4BC51D.svg?style=flat)](https://cocoapods.org)
+[![CocoaPods compatible](https://img.shields.io/badge/CocoaPods-compatible-4BC51D.svg?style=flat)](https://cocoapods.org)
 ![Version](https://img.shields.io/cocoapods/v/IFAFoundation.svg)
 ![Licence](https://img.shields.io/cocoapods/l/IFAFoundation.svg)
 ![Platform](https://img.shields.io/cocoapods/p/IFAFoundation.svg)
@@ -14,7 +14,7 @@ Additional documentation and sample code are coming soon.
 
 ## How to integrate IFAFoundation ##
 
-IFAFoundation can be integrated to your project via Cocoapods or Carthage.
+IFAFoundation can be integrated to your project via CocoaPods or Carthage.
 
 ## Latest API Documentation ##
 


### PR DESCRIPTION
This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>

<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>


Created with [`cocoapods-readme`](https://github.com/dkhamsing/cocoapods-readme).  
